### PR TITLE
fix error "We need CPython 2.7, 3.2 .. 3.9 to compile source code; you are running 4.0"

### DIFF
--- a/xpython/byteop/__init__.py
+++ b/xpython/byteop/__init__.py
@@ -8,7 +8,8 @@ def get_byteop(vm, python_version, is_pypy):
     """Get Python byteop for given integer Python version, e.g. 2.7, 3.2, 3.5..., and the
     platform is_pypy. vm.VMError will be raised if we can't find a suitable version.
     """
-
+    if not type(python_version) is tuple:
+        python_version=(int(str(python_version)[0]),int(str(python_version)[2]))
     python_version = python_version[:2]
     if python_version < (3, 0):
         if python_version >= (2, 6):
@@ -104,7 +105,7 @@ def get_byteop(vm, python_version, is_pypy):
 
                 byteop = ByteOp39(vm)
 
-            elif python_version == (3, 10):
+            elif python_version == (3, 10) or python_version == (4, 0):
                 from xpython.byteop.byteop310 import ByteOp310
 
                 byteop = ByteOp310(vm)

--- a/xpython/execfile.py
+++ b/xpython/execfile.py
@@ -101,10 +101,10 @@ def exec_code_object(
 def get_supported_versions(is_pypy, is_bytecode):
     if is_bytecode:
         supported_versions = SUPPORTED_BYTECODE
-        mess = "Python 2.4 .. 2.7, 3.2 .. 3.9"
+        mess = "Python 2.4 .. 2.7, 3.2 .. 3.10"
     else:
         supported_versions = SUPPORTED_PYPY if IS_PYPY else SUPPORTED_PYTHON
-        mess = "PYPY 2.7, 3.2, 3.5 and 3.6" if is_pypy else "CPython 2.7, 3.2 .. 3.9"
+        mess = "PYPY 2.7, 3.2, 3.5 and 3.6" if is_pypy else "CPython 2.7, 3.2 .. 3.10"
     return supported_versions, mess
 
 
@@ -302,10 +302,10 @@ def run_python_string(
 
     try:
         supported_versions, mess = get_supported_versions(IS_PYPY, is_bytecode=False)
-        if PYTHON_VERSION not in supported_versions:
+        if PYTHON_VERSION_TRIPLE[:2] not in supported_versions:
             raise CannotCompileError(
                 "We need %s to compile source code; you are running %s"
-                % (mess, PYTHON_VERSION)
+                % (mess, version_tuple_to_str())
             )
 
         # `compile` still needs the last line to be clean,

--- a/xpython/stdlib/builtins.py
+++ b/xpython/stdlib/builtins.py
@@ -26,6 +26,8 @@ def make_compatible_builtins(builtins: dict, target_python: tuple):
     This is needed when doing cross-bytecode interpretation
     because the list of builtin functions varies between different Python versions.
     """
+    if not type(target_python) is tuple:
+        target_python=(int(str(target_python)[0]),int(str(target_python)[2]))
     short_name = f"builtins_{target_python[0]}{target_python[1]}"
     import_name = f"xpython.stdlib.{short_name}"
     try:

--- a/xpython/vm.py
+++ b/xpython/vm.py
@@ -150,6 +150,7 @@ class PyVM(object):
         self.last_exception = None
         self.last_traceback_limit = None
         self.last_traceback = None
+        python_version=PYTHON_VERSION_TRIPLE
         self.version = python_version
         self.is_pypy = is_pypy
         self.format_instruction = format_instruction_func


### PR DESCRIPTION
Fixes python version error when running `python3.10 -m xpython -c "print('Hello World')"`
Also checks for python version `(4, 0)` which seems to match python 3.10.

```bash
user@localhost ~ $ python3.10 -m xpython -c "print('Hello World')"                                                                                                  
We need CPython 2.7, 3.2 .. 3.9 to compile source code; you are running 4.0
user@localhost ~ $
```
after installing with `sudo python3.10 -m pip install git+https://github.com/LinuxUserGD/x-python.git`:
```bash
user@localhost ~ $ python3.10 -m xpython -c "print('Hello World')"
Hello World
user@localhost ~ $
```